### PR TITLE
Add grid system

### DIFF
--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -22,18 +22,11 @@
   .go-column--#{$name} {
     flex-basis: percentage($size);
 
-    @if ($name < 25) {
-      @media (max-width: $breakpoint_tablet) {
-        flex-basis: 50%;
-      }
-
-      @media (max-width: $breakpoint_mobile) {
-        flex-basis: 100%;
-      }
+    @if ($name <= 25) {
+      @extend %tablet__flex-basis--50;
+      @extend %mobile__flex-basis--100; 
     } @else {
-      @media (max-width: $breakpoint_tablet) {
-        flex-basis: 100%;
-      }
+      @extend %tablet__flex-basis--100; 
     }
   }
 }

--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -1,0 +1,39 @@
+.go-container {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0rem -1rem;
+}
+
+.go-container--no-wrap {
+  flex-wrap: nowrap;
+}
+
+.go-column {
+  flex-grow: 1;
+  flex-shrink: 1;
+  padding: 0 1rem 2rem 1rem;
+
+  > *:not(.go-container) {
+    width: 100%;
+  }
+}
+
+@each $name, $size in $column_sizes {
+  .go-column--#{$name} {
+    flex-basis: percentage($size);
+
+    @if ($name < 25) {
+      @media (max-width: $breakpoint_tablet) {
+        flex-basis: 50%;
+      }
+
+      @media (max-width: $breakpoint_mobile) {
+        flex-basis: 100%;
+      }
+    } @else {
+      @media (max-width: $breakpoint_tablet) {
+        flex-basis: 100%;
+      }
+    }
+  }
+}

--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -9,13 +9,16 @@
 }
 
 .go-column {
-  flex-grow: 1;
-  flex-shrink: 1;
-  padding: 0 1rem 2rem 1rem;
+  flex: 1 1 auto;
+  padding: 0 1rem 2rem;
 
   > *:not(.go-container) {
     width: 100%;
   }
+}
+
+.go-column--no-padding {
+  padding-bottom: 0;
 }
 
 @each $name, $size in $column_sizes {

--- a/base/_placeholders.scss
+++ b/base/_placeholders.scss
@@ -1,0 +1,20 @@
+// Placeholder classes will honor the cascade
+// in the order that they are defined and imported.
+// Not from the place in which they are extended to.
+%mobile__flex-basis--100 {
+  @media (max-width: $breakpoint_mobile) {
+    flex-basis: 100%;
+  }
+}
+
+%tablet__flex-basis--50 {
+  @media (max-width: $breakpoint_tablet) {
+    flex-basis: 50%;
+  }
+}
+
+%tablet__flex-basis--100 {
+  @media (max-width: $breakpoint_tablet) {
+    flex-basis: 100%;
+  }
+}

--- a/base/_variables.scss
+++ b/base/_variables.scss
@@ -6,7 +6,7 @@ $global-radius: 4px;
 $global-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
 
 // Structural
-$column_sizes: (25: 1/4, 33: 1/3, 50: 1/5, 66: 2/3, 75: 3/4);
+$column_sizes: (25: 1/4, 33: 1/3, 50: 2/4, 66: 2/3, 75: 3/4, 100: 1);
 
 // Breakpoints
 $breakpoint-mobile: 768px;

--- a/base/_variables.scss
+++ b/base/_variables.scss
@@ -5,6 +5,9 @@
 $global-radius: 4px;
 $global-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
 
+// Structural
+$column_sizes: (25: 1/4, 33: 1/3, 50: 1/5, 66: 2/3, 75: 3/4);
+
 // Breakpoints
 $breakpoint-mobile: 768px;
 $breakpoint-tablet: 1024px;

--- a/gosheets.scss
+++ b/gosheets.scss
@@ -1,1 +1,2 @@
 @import './base/variables';
+@import './base/grid';

--- a/gosheets.scss
+++ b/gosheets.scss
@@ -1,2 +1,3 @@
 @import './base/variables';
 @import './base/grid';
+@import './base/placeholders';


### PR DESCRIPTION
#### Add base grid system

This adds a `$column_sizes` utility variable that we then use to
build out our foundational grid system.

#### Refactor grid system using placeholder classes

Using sass placeholder classes we are able to refactor down our
grid system output substantially.

#### Add a modifier class to remove padding from the bottom of columns

In cases where a grid column is nested within another grid column
an undesired padding might be added to the bottom. This modifier
`.go-column--no-padding` class provides a way to remove that.

## Example Usage
The example below produces a grid with three columns. The first two columns are 25% of the width of the container and the third is 50%.
```html
<div class="go-container">
  <div class="go-column go-column--25">25% column</div>
  <div class="go-column go-column--25">25% column</div>
  <div class="go-column go-column--50">50% column</div>
</div>
```
![grid](https://user-images.githubusercontent.com/1075489/54777695-48104600-4be9-11e9-881e-08468c6b6109.png)

You can mess around with this code here: https://codepen.io/AlexOverbeck/pen/JzeJaJ?editors=1000