### PR TITLE
Exposes the layout gutter via variable to the variables file

### DIFF
--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -1,7 +1,7 @@
 .go-container {
   display: flex;
   flex-wrap: wrap;
-  margin: 0rem -1rem;
+  margin: 0rem (-$column-gutter);
 }
 
 .go-container--no-wrap {
@@ -10,7 +10,7 @@
 
 .go-column {
   flex: 1 1 auto;
-  padding: 0 1rem 2rem;
+  padding: 0 ($column-gutter/2) $column-gutter;
 
   > *:not(.go-container) {
     width: 100%;
@@ -21,7 +21,7 @@
   padding-bottom: 0;
 }
 
-@each $name, $size in $column_sizes {
+@each $name, $size in $column-sizes {
   .go-column--#{$name} {
     flex-basis: percentage($size);
 

--- a/base/_variables.scss
+++ b/base/_variables.scss
@@ -6,7 +6,8 @@ $global-radius: 4px;
 $global-box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
 
 // Structural
-$column_sizes: (25: 1/4, 33: 1/3, 50: 2/4, 66: 2/3, 75: 3/4, 100: 1);
+$column-gutter: 2rem;
+$column-sizes: (25: 1/4, 33: 1/3, 50: 2/4, 66: 2/3, 75: 3/4, 100: 1);
 
 // Breakpoints
 $breakpoint-mobile: 768px;


### PR DESCRIPTION
Exposing this gutter variable will help us more consistently apply
spacing in our structural styles.

This also fixes a stylistic discrepancy in how a variable was named.