### PR TITLE
Fixes background color on go-hint--error class and closes #14

### DIFF
--- a/base/_hints.scss
+++ b/base/_hints.scss
@@ -28,7 +28,7 @@
   padding-top: 0;
 
   &::before {
-    background-color: $ui-color-negative-gradient;
+    background-image: $ui-color-negative-gradient;
   }
 }
 


### PR DESCRIPTION
## Purpose
We used tried to apply a gradient to background-color which
doesn't work. As a result our error modifier does not apply the
appropriate background. This changes background-color to
background-image.