### PR TITLE
Adds support for dark themed buttons

### DIFF
--- a/base/_buttons.scss
+++ b/base/_buttons.scss
@@ -4,7 +4,7 @@ $button__background--disabled: rgba($theme-light-border, .3);
 $button__background--loading: rgba($theme-light-border, .4);
 
 .go-button {
-  @include go-button-special;
+  @include go-button-mutator;
 
   background-origin: padding-box, border-box; // This is important
   background-repeat: no-repeat; // This is important
@@ -47,7 +47,7 @@ $button__background--loading: rgba($theme-light-border, .4);
   }
 
   &:disabled:not(.go-button--loading) {
-    @include go-button-special;
+    @include go-button-mutator;
 
     cursor: not-allowed;
 
@@ -71,7 +71,7 @@ $button__background--loading: rgba($theme-light-border, .4);
 }
 
 .go-button--dark {
-  @include go-button-special($dark-theme: true);
+  @include go-button-mutator($dark-theme: true);
 
   color: $theme-dark-text-color;
 
@@ -85,7 +85,7 @@ $button__background--loading: rgba($theme-light-border, .4);
   }
 
   &:disabled:not(.go-button--loading) {
-    @include go-button-special(
+    @include go-button-mutator(
       $from: $base-dark-secondary,
       $to: $base-dark-secondary,
       $dark-theme: true
@@ -112,7 +112,7 @@ $button__background--loading: rgba($theme-light-border, .4);
 }
 
 .go-button--negative {
-  @include go-button-special(
+  @include go-button-mutator(
     $gradient: $ui-color-negative-gradient,
     $dark-modifier: true,
     $loading-modifier: rgba($ui-color-negative, .2),
@@ -123,7 +123,7 @@ $button__background--loading: rgba($theme-light-border, .4);
 }
 
 .go-button--neutral {
-  @include go-button-special(
+  @include go-button-mutator(
     $gradient: $ui-color-neutral-gradient,
     $dark-modifier: true,
     $loading-modifier: rgba($ui-color-neutral, .2),
@@ -134,7 +134,7 @@ $button__background--loading: rgba($theme-light-border, .4);
 }
 
 .go-button--positive {
-  @include go-button-special(
+  @include go-button-mutator(
     $gradient: $ui-color-positive-gradient,
     $dark-modifier: true,
     $loading-modifier: rgba($ui-color-positive, .3),

--- a/base/_buttons.scss
+++ b/base/_buttons.scss
@@ -14,8 +14,8 @@ $button__background--loading: rgba($theme-light-border, .4);
   cursor: pointer;
   display: inline-block;
   font-family: $heading-font-stack;
-  font-size: 0.875rem;
-  letter-spacing: 0.015rem;
+  font-size: .875rem;
+  letter-spacing: .015rem;
   line-height: 1rem;
   outline-color: $theme-light-border;
   outline-offset: -2px;
@@ -86,9 +86,9 @@ $button__background--loading: rgba($theme-light-border, .4);
 
   &:disabled:not(.go-button--loading) {
     @include go-button-mutator(
+      $dark-theme: true,
       $from: $base-dark-secondary,
       $to: $base-dark-secondary,
-      $dark-theme: true
     );
 
     &:hover::before,
@@ -113,10 +113,10 @@ $button__background--loading: rgba($theme-light-border, .4);
 
 .go-button--negative {
   @include go-button-mutator(
-    $gradient: $ui-color-negative-gradient,
     $dark-modifier: true,
-    $loading-modifier: rgba($ui-color-negative, .2),
-    $hover-background: $ui-background-negative
+    $gradient: $ui-color-negative-gradient,
+    $hover-background: $ui-background-negative,
+    $loading-modifier: rgba($ui-color-negative, .2)
   );
 
   outline-color: $ui-color-negative-active;
@@ -124,10 +124,10 @@ $button__background--loading: rgba($theme-light-border, .4);
 
 .go-button--neutral {
   @include go-button-mutator(
-    $gradient: $ui-color-neutral-gradient,
     $dark-modifier: true,
-    $loading-modifier: rgba($ui-color-neutral, .2),
-    $hover-background: $ui-background-neutral
+    $gradient: $ui-color-neutral-gradient,
+    $hover-background: $ui-background-neutral,
+    $loading-modifier: rgba($ui-color-neutral, .2)
   );
 
   outline-color: $ui-color-neutral-active;
@@ -135,10 +135,10 @@ $button__background--loading: rgba($theme-light-border, .4);
 
 .go-button--positive {
   @include go-button-mutator(
-    $gradient: $ui-color-positive-gradient,
     $dark-modifier: true,
-    $loading-modifier: rgba($ui-color-positive, .3),
-    $hover-background: $ui-background-positive
+    $gradient: $ui-color-positive-gradient,
+    $hover-background: $ui-background-positive,
+    $loading-modifier: rgba($ui-color-positive, .3)
   );
 
   outline-color: $ui-color-positive-active;

--- a/base/_buttons.scss
+++ b/base/_buttons.scss
@@ -4,7 +4,7 @@ $button__background--disabled: rgba($theme-light-border, .3);
 $button__background--loading: rgba($theme-light-border, .4);
 
 .go-button {
-  @include button-border-gradient;
+  @include go-button-special;
 
   background-origin: padding-box, border-box; // This is important
   background-repeat: no-repeat; // This is important
@@ -47,7 +47,7 @@ $button__background--loading: rgba($theme-light-border, .4);
   }
 
   &:disabled:not(.go-button--loading) {
-    @include button-border-gradient;
+    @include go-button-special;
 
     cursor: not-allowed;
 
@@ -70,6 +70,34 @@ $button__background--loading: rgba($theme-light-border, .4);
   }
 }
 
+.go-button--dark {
+  @include go-button-special($dark-theme: true);
+
+  color: $theme-dark-text-color;
+
+  &::before {
+    border-color: $theme-dark-bg;
+  }
+
+  &:hover,
+  &:disabled {
+    color: $base-light;
+  }
+
+  &:disabled:not(.go-button--loading) {
+    @include go-button-special(
+      $from: $base-dark-secondary,
+      $to: $base-dark-secondary,
+      $dark-theme: true
+    );
+
+    &:hover::before,
+    &::before {
+      background: rgba($base-dark-secondary, .4);
+    }
+  }
+}
+
 .go-button--loading {
   color: $base-dark-secondary;
   cursor: wait;
@@ -84,48 +112,36 @@ $button__background--loading: rgba($theme-light-border, .4);
 }
 
 .go-button--negative {
-  @include button-border-gradient($gradient: $ui-color-negative-gradient);
+  @include go-button-special(
+    $gradient: $ui-color-negative-gradient,
+    $dark-modifier: true,
+    $loading-modifier: rgba($ui-color-negative, .2),
+    $hover-background: $ui-background-negative
+  );
 
   outline-color: $ui-color-negative-active;
-
-  &:hover:not(.go-button--loading)::before {
-    background: $ui-background-negative;
-  }
-
-  &.go-button--loading::before {
-    background: linear-gradient(to right, transparent, rgba($ui-color-negative, .2), transparent);
-    background-size: 1000px 100%;
-  }
 }
 
 .go-button--neutral {
-  @include button-border-gradient($gradient: $ui-color-neutral-gradient);
+  @include go-button-special(
+    $gradient: $ui-color-neutral-gradient,
+    $dark-modifier: true,
+    $loading-modifier: rgba($ui-color-neutral, .2),
+    $hover-background: $ui-background-neutral
+  );
 
   outline-color: $ui-color-neutral-active;
-
-  &:hover:not(.go-button--loading)::before {
-    background: $ui-background-neutral;
-  }
-
-  &.go-button--loading::before {
-    background: linear-gradient(to right, transparent, rgba($ui-color-neutral, .2), transparent);
-    background-size: 1000px 100%;
-  }
 }
 
 .go-button--positive {
-  @include button-border-gradient($gradient: $ui-color-positive-gradient);
+  @include go-button-special(
+    $gradient: $ui-color-positive-gradient,
+    $dark-modifier: true,
+    $loading-modifier: rgba($ui-color-positive, .3),
+    $hover-background: $ui-background-positive
+  );
 
   outline-color: $ui-color-positive-active;
-
-  &:hover:not(.go-button--loading)::before {
-    background: $ui-background-positive;
-  }
-
-  &.go-button--loading::before {
-    background: linear-gradient(to right, transparent, rgba($ui-color-positive, .3), transparent);
-    background-size: 1000px 100%;
-  }
 }
 
 @keyframes background-animation {

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -1,12 +1,37 @@
-@mixin button-border-gradient(
+@mixin go-button-special(
   $from: $theme-light-border,
   $to: $theme-light-border,
-  $gradient: null
+  $gradient: null,
+  $dark-theme: false,
+  $dark-modifier: false,
+  $loading-modifier: false,
+  $hover-background: false
 ) {
-  $white-gradient: linear-gradient($theme-light-bg, $theme-light-bg);
+  $light-gradient: linear-gradient($theme-light-bg, $theme-light-bg);
+  $dark-gradient: linear-gradient($theme-dark-bg, $theme-dark-bg);
+  $selected-gradient: if($dark-theme, $dark-gradient, $light-gradient);
   $color-gradient: if($gradient, $gradient, linear-gradient(to bottom, $from, $to));
 
-  background-image: $white-gradient, $color-gradient;
+  background-image: $selected-gradient, $color-gradient;
+
+  @if ($dark-modifier) {
+    &.go-button--dark {
+      background-image: $dark-gradient, $color-gradient;
+    }
+  }
+
+  @if (type-of($loading-modifier) == color) {
+    &.go-button--loading::before {
+      background: linear-gradient(to right, transparent, $loading-modifier, transparent);
+      background-size: 1000px 100%;
+    }
+  }
+
+  @if ($hover-background) {
+    &:hover:not(.go-button--loading)::before {
+      background: $hover-background;
+    }
+  }
 }
 
 @mixin fill-text-background($fill: null, $color: $base-dark) {

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -1,4 +1,4 @@
-@mixin go-button-special(
+@mixin go-button-mutator(
   $from: $theme-light-border,
   $to: $theme-light-border,
   $gradient: null,

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -1,16 +1,16 @@
 @mixin go-button-mutator(
-  $from: $theme-light-border,
-  $to: $theme-light-border,
-  $gradient: null,
-  $dark-theme: false,
   $dark-modifier: false,
+  $dark-theme: false,
+  $from: $theme-light-border,
+  $gradient: null,
+  $hover-background: false,
   $loading-modifier: false,
-  $hover-background: false
+  $to: $theme-light-border
 ) {
-  $light-gradient: linear-gradient($theme-light-bg, $theme-light-bg);
-  $dark-gradient: linear-gradient($theme-dark-bg, $theme-dark-bg);
-  $selected-gradient: if($dark-theme, $dark-gradient, $light-gradient);
   $color-gradient: if($gradient, $gradient, linear-gradient(to bottom, $from, $to));
+  $dark-gradient: linear-gradient($theme-dark-bg, $theme-dark-bg);
+  $light-gradient: linear-gradient($theme-light-bg, $theme-light-bg);
+  $selected-gradient: if($dark-theme, $dark-gradient, $light-gradient);
 
   background-image: $selected-gradient, $color-gradient;
 
@@ -27,7 +27,7 @@
     }
   }
 
-  @if ($hover-background) {
+  @if (type-of($hover-background) == color) {
     &:hover:not(.go-button--loading)::before {
       background: $hover-background;
     }

--- a/base/_variables.scss
+++ b/base/_variables.scss
@@ -58,6 +58,7 @@ $theme-dark-bg: $base-dark;
 $theme-dark-bg-active: darken($base-dark, 4);
 $theme-dark-bg-hover: darken($base-dark, 7);
 $theme-dark-color: $base-light;
+$theme-dark-text-color: mix($base-light, $base-light-secondary);
 $theme-dark-color-hover: darken($base-light, 20);
 $theme-dark-border: $base-dark-secondary;
 


### PR DESCRIPTION
## Adds support for dark themed buttons
This adds several variations to the button styles to allow us to
use buttons on a dark background. It abstracts most of the code to
do so out into the go-button-special mixin.

## Testing
A compiled version of this sass exists on codepen at:
https://codepen.io/AlexOverbeck/pen/vMzPxY?editors=1100