### PR TITLE
Fixes an issue with the fill-text-background mixin

### DIFF
--- a/base/_buttons.scss
+++ b/base/_buttons.scss
@@ -63,10 +63,9 @@ $button__background--loading: rgba($theme-light-border, .4);
 
   .go-button__icon {
     font-size: 1.25rem;
-    line-height: inherit;
     margin-left: -$column-gutter--quarter;
     margin-right: $column-gutter--quarter;
-    vertical-align: top;
+    vertical-align: text-bottom;
   }
 }
 

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -38,7 +38,7 @@
   // sass-lint:disable-block no-vendor-prefixes property-sort-order
   color: $color;
 
-  @supports (-webkit-background-clip: text) or (background-clip: text) {
+  @supports (background-clip: text) or (-webkit-background-clip: text) {
     @if ($fill) {
       background: $fill;
       background-clip: text;


### PR DESCRIPTION
There was an odd issue that was preventing the fill-text-background
mixin from working properly in a webkit based browser. If you flip
the statements in the supports condition everything seems to work
fine.

This also adjusts an issue where icons were getting cut off inside
of buttons due to a mismatch in line height.