### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: ruby
+language: node
 
 before_install:
-  - gem install sass
+  - npm install -g sass
 
 script:
-  - "scripts/test-compilation.rb"
+  - npm test

--- a/gosheets.scss
+++ b/gosheets.scss
@@ -1,4 +1,4 @@
-@import './base/variables';
+// @import './base/variables';
 @import './base/mixins';
 @import './base/grid';
 @import './base/typography';

--- a/gosheets.scss
+++ b/gosheets.scss
@@ -1,4 +1,4 @@
-// @import './base/variables';
+@import './base/variables';
 @import './base/mixins';
 @import './base/grid';
 @import './base/typography';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "style": "gosheets.scss",
   "license": "MIT",
   "scripts": {
-    "test": "npm test"
+    "test": "sass gosheets.scss gosheets.css"
   },
   "repository": {
     "type": "git",

--- a/scripts/test-compilation.rb
+++ b/scripts/test-compilation.rb
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-
-result = `sass gosheets.scss gosheets.css`
-raise result unless result.empty?
-raise 'When compiled the module should output some CSS' unless File.exist?('gosheets.css')
-puts 'Regular compile worked successfully'


### PR DESCRIPTION
This switches to using node sass to run tests. It simply has node compile the sass inside the `npm test` command. It doesn't cover all the bases, but it at least fails on Travis CI if we can't compile `gosheets.scss`.

#### Testing
Failing build: https://travis-ci.org/mobi/gosheets/builds/535955359
Passing build: https://travis-ci.org/mobi/gosheets/builds/535957559