### PR TITLE
Fixes an issue where buttons with icons were a slightly different height

### DIFF
--- a/base/_buttons.scss
+++ b/base/_buttons.scss
@@ -63,9 +63,13 @@ $button__background--loading: rgba($theme-light-border, .4);
 
   .go-button__icon {
     font-size: 1.25rem;
-    margin-left: -$column-gutter--quarter;
+    line-height: 1rem;
+    margin-bottom: -.2rem;
+    margin-left: -$column-gutter--half;
     margin-right: $column-gutter--quarter;
-    vertical-align: text-bottom;
+    margin-top: -.2rem;
+    padding: .2rem 0;
+    vertical-align: top;
   }
 }
 


### PR DESCRIPTION
The icons inside of buttons where throwing off the overall height
of the button. There was an additional issue where the icon
would clip at the height of the text. The addition of padding and
negative margin gives the buttons a little more space to prevent
that issue.

#### Before
<img width="1119" alt="Screen Shot 2019-05-24 at 11 36 08 AM" src="https://user-images.githubusercontent.com/1075489/58339736-40069980-7e18-11e9-84d2-49e7ac6af5f8.png">

#### After
<img width="1117" alt="Screen Shot 2019-05-24 at 11 36 24 AM" src="https://user-images.githubusercontent.com/1075489/58339745-46951100-7e18-11e9-831e-1eec269e650b.png">
