### PR TITLE
Adds styles necessary to support forms displayed on a dark background

### DIFF
--- a/base/_forms.scss
+++ b/base/_forms.scss
@@ -1,3 +1,5 @@
+$input--disabled-background: rgba($base-dark-secondary, .4);
+
 .go-form__fieldset {
   border: 1px solid $theme-light-border;
   margin-bottom: $column-gutter--double;
@@ -6,6 +8,23 @@
   &:disabled {
     background: $theme-light-app-bg;
     cursor: not-allowed;
+
+    label:not([class]),
+    .go-form__label {
+      cursor: not-allowed;
+    }
+  }
+}
+
+.go-form--dark .go-form__fieldset,
+.go-form__fieldset--dark {
+  &:disabled {
+    background: $base-dark-secondary;
+  }
+
+  label:not([class]),
+  .go-form__label {
+    color: $theme-light-border;
   }
 }
 
@@ -31,11 +50,17 @@ label:not([class]),
   padding-bottom: $column-gutter--three-quarters;
 }
 
+.go-form--dark .go-form__label,
+.go-form__label--dark {
+  color: $theme-dark-color;
+}
+
 .go-form__label--inline {
   display: inline-block;
 }
 
 .go-form__input {
+  background: transparent;
   border: 1px solid $theme-light-border;
   border-radius: $global-radius;
   font-family: inherit;
@@ -56,12 +81,11 @@ label:not([class]),
   }
 
   &:disabled {
-    @extend %input--disabled;
+    @include disabled-input;
   }
 }
 
 .go-form__checkbox {
-  margin: 0;
   margin-bottom: $column-gutter--three-quarters;
   margin-right: $column-gutter--three-quarters;
   width: auto;
@@ -82,7 +106,21 @@ label:not([class]),
   outline-color: $ui-color-positive;
 
   &:disabled {
-    @extend %input--disabled;
+    @include disabled-input;
+  }
+}
+
+.go-form--dark .go-form__input,
+.go-form--dark .go-form__select,
+.go-form__input--dark,
+.go-form__select--dark {
+  background-color: transparent;
+  color: $theme-dark-color;
+
+  &:disabled {
+    background-color: $input--disabled-background;
+    border-color:  $base-dark-secondary;
+    color: $theme-light-border;
   }
 }
 

--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -52,3 +52,14 @@
     }
   }
 }
+
+@mixin disabled-input {
+  background: {
+    color: $theme-light-app-bg;
+    image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAqCAYAAADS4VmSAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAYdJREFUeNrsV+1tgzAQLSgDeIM2G6QbkAnICHSCigmaTICYIGzQMEHYoBmBbsAG7bv2IiHLxh848McnnSzL+O7d+e7ZJE+O0ratwJBBd9LSDdrleT642EscHL9g+IAWhk8b6AlA+mAA4PyA4QwVlngpC28AcZkNAM4Ldu4jBKLxBgDndM5fmggpum+eP0MPmgy9AsRN52NjiOBTc8alXGwAW2KoFDVCNrbOGdCknorraMjakYvV6ijSCVu5NO9Mzv82/X/TGWxZAcikee1QfLXBlhUAIUV2sfWu+FY4AWDSWURSTQT9qgCWlNUBJFLfj89e7uWTo+2p/f2dFxK+Xq+K6/XRQvS8T5k+dytkn3xWqcX9/kgpYhdEABHAZsbegcnk3tNiyQwQjW5Bp3tSfvM1XncBqPjHcU/HTlXviOvU6ydUBmrPtWAABs+1YACE51owAO+ea8HaMEOxncd/R/ymqFwL0LcLgvLAHCISPhHHuyACiABUAJoV/TcEoBwRytJ/RuWvAAMAsBxvzn+b8C4AAAAASUVORK5CYII=');
+    position: right $column-gutter top .8rem;
+    repeat: no-repeat;
+    size: auto $column-gutter--three-quarters;
+  }
+  cursor: not-allowed;
+}

--- a/base/_placeholders.scss
+++ b/base/_placeholders.scss
@@ -19,15 +19,6 @@
   }
 }
 
-%input--disabled {
-  background: $theme-light-app-bg;
-  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAqCAYAAADS4VmSAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAYdJREFUeNrsV+1tgzAQLSgDeIM2G6QbkAnICHSCigmaTICYIGzQMEHYoBmBbsAG7bv2IiHLxh848McnnSzL+O7d+e7ZJE+O0ratwJBBd9LSDdrleT642EscHL9g+IAWhk8b6AlA+mAA4PyA4QwVlngpC28AcZkNAM4Ldu4jBKLxBgDndM5fmggpum+eP0MPmgy9AsRN52NjiOBTc8alXGwAW2KoFDVCNrbOGdCknorraMjakYvV6ijSCVu5NO9Mzv82/X/TGWxZAcikee1QfLXBlhUAIUV2sfWu+FY4AWDSWURSTQT9qgCWlNUBJFLfj89e7uWTo+2p/f2dFxK+Xq+K6/XRQvS8T5k+dytkn3xWqcX9/kgpYhdEABHAZsbegcnk3tNiyQwQjW5Bp3tSfvM1XncBqPjHcU/HTlXviOvU6ydUBmrPtWAABs+1YACE51owAO+ea8HaMEOxncd/R/ymqFwL0LcLgvLAHCISPhHHuyACiABUAJoV/TcEoBwRytJ/RuWvAAMAsBxvzn+b8C4AAAAASUVORK5CYII=');
-  background-position: right $column-gutter top .8rem;
-  background-repeat: no-repeat;
-  background-size: auto $column-gutter--three-quarters;
-  cursor: not-allowed;
-}
-
 %element--no-margin {
   margin: 0;
 }

--- a/base/_typography.scss
+++ b/base/_typography.scss
@@ -75,7 +75,9 @@ a:not([class]) {
   color: $theme-light-color;
   transition: $global-transition-duration $global-transition-timing;
 
-  &:visited, &:active, &:focus {
+  &:active,
+  &:focus,
+  &:visited {
     color: $theme-light-color;
   }
 
@@ -93,6 +95,6 @@ ol,
 
 ol > li,
 .go-ordered-list__item {
-  margin: $column-gutter--half 0;
   line-height: 1.5;
+  margin: $column-gutter--half 0;
 }


### PR DESCRIPTION
# Dark forms

This adds support for forms to be displayed on a dark background. Dark forms are mostly like the default forms with a few alterations based on the state of the input. Labels and text show up as a light color so they are legible on a dark background. When the input is in a `disabled` state, the input will darken slightly to better portray itself as such.

### Implementation
The dark form effect can be achieved in one of two ways. Generally speaking we will have a whole form that we need to make dark. In this case, we can simply add the `.go-form--dark` modifier class to the surrounding form element.

```html
<form class="go-form go-form--dark">
  <label class="go-form__label">First Name</label>
  <input class="go-form__input" placeholder="Jonny" type="text">
</form>
```

There might be cases, however, where individual inputs are not contained within a form element. The dark input styles can be applied to individual elements by adding the `--dark` modifier to any individual element as well.
```html
<label class="go-form__label go-form__label--dark">First Name</label>
<input class="go-form__input go-form__input--dark" placeholder="Jonny" type="text">
<select class="go-form__select go-form__select--dark">
  <option>Select a thing</option>
</select>
<fieldset class="go-form__fieldset go-form__fieldset--dark">
  <!-- ... -->
<fieldset> 
```

<img width="596" alt="Screen Shot 2019-06-06 at 10 58 17 AM" src="https://user-images.githubusercontent.com/1075489/59043319-05562580-884a-11e9-9737-87a8a209f22c.png">
