### PR TITLE
Expanded font-stack for better support in app

### DIFF
--- a/base/_typography.scss
+++ b/base/_typography.scss
@@ -1,3 +1,7 @@
+body {
+  font-family: $base-font-stack;
+}
+
 h1,
 .go-heading-1 {
   font-family: $heading-font-stack;

--- a/base/_variables.scss
+++ b/base/_variables.scss
@@ -31,8 +31,8 @@ $weight-light: 300;
 $weight-regular: 400;
 $weight-bold: 700;
 
-$base-font-stack: 'Roboto', 'Arial', sans-serif;
-$heading-font-stack: 'Roboto', 'Arial', sans-serif;
+$base-font-stack: 'Roboto', 'Lato', 'Helvetica', 'Arial', sans-serif;
+$heading-font-stack: 'Roboto', 'Bryant', 'Helvetica', 'Arial', sans-serif;
 
 // Colors
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Added a fall-back for both headings and body fonts for Lato and Bryant respectively.