### PR TITLE
Added a button-group class to replace foundation button groups

### DIFF
--- a/base/_buttons.scss
+++ b/base/_buttons.scss
@@ -156,3 +156,18 @@ $button__background--loading: rgba($theme-light-border, .4);
     background-position: 1000px 0;
   }
 }
+
+.go-button-group {
+  display: inline-flex;
+  justify-content: flex-start;
+  list-style: none;
+  margin: 0;
+}
+
+.go-button-group__item {
+  margin-right: 0.5rem;
+
+  &:last-child {
+    margin-right: 0;
+  }
+}


### PR DESCRIPTION
## Source
https://mobi.teamwork.com/#tasks/13544497

This will be implemented like:
```
<ul class="go-button-group">
  <li class="go-button-group__item">
    <go-button>Button 1</go-button>
  </li>
  <li class="go-button-group__item">
    <go-button>Button 2</go-button>
  </li>
</ul>
```

![Screen Shot 2019-06-12 at 11 34 39 AM](https://user-images.githubusercontent.com/11966331/59365187-21ecd480-8d06-11e9-92e5-de3f80e606cd.png)
