### PR TITLE
Table styles

### DIFF
--- a/base/_mixins.scss
+++ b/base/_mixins.scss
@@ -63,3 +63,15 @@
   }
   cursor: not-allowed;
 }
+
+@mixin transition(
+  $property: all,
+  $duration: $global-transition-duration,
+  $timing: $global-transition-timing
+) {
+  transition: {
+    duration: $global-transition-duration;
+    property: $property;
+    timing-function: $timing;
+  };
+}

--- a/base/_tables.scss
+++ b/base/_tables.scss
@@ -1,0 +1,61 @@
+.go-table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.go-table__table {
+  border-spacing: 0;
+  color: $theme-light-color;
+  width: 100%;
+}
+
+.go-table__head-column {
+  color: $theme-light-color;
+  cursor: pointer;
+  font-size: .75rem;
+  font-weight: bold;
+  letter-spacing: 1pt;
+  padding: 1rem 1.25rem;
+  position: relative;
+  text-align: left;
+  text-transform: uppercase;
+  transition: background .25s cubic-bezier(.25, .8, .25, 1);
+  white-space: nowrap;
+
+  &:hover {
+    background: $theme-light-app-bg;
+  }
+
+  &:first-of-type {
+    border-top-left-radius: $global-radius;
+  }
+
+  &:last-of-type {
+    border-top-right-radius: $global-radius;
+  }
+}
+
+.go-table__head-content {
+  display: flex;
+  line-height: 1;
+}
+
+.go-table__sort-icon {
+  display: inline-block;
+  height: .75rem;
+  padding-left: .25rem;
+}
+
+.go-table__body-column {
+  border-bottom: 1px solid $theme-light-app-bg;
+  font-size: .875rem;
+  padding: .875rem 1.25rem;
+
+  .go-table__body-row:first-child & {
+    border-top: 1px solid $theme-light-app-bg;
+  }
+
+  .go-table__body-row:last-child & {
+    border-bottom: 0;
+  }
+}

--- a/base/_tables.scss
+++ b/base/_tables.scss
@@ -10,6 +10,8 @@
 }
 
 .go-table__head-column {
+  @include transition(background);
+
   color: $theme-light-color;
   cursor: pointer;
   font-size: .75rem;
@@ -19,7 +21,6 @@
   position: relative;
   text-align: left;
   text-transform: uppercase;
-  transition: background .25s cubic-bezier(.25, .8, .25, 1);
   white-space: nowrap;
 
   &:hover {
@@ -84,6 +85,8 @@
 }
 
 .go-table-toolbar__button {
+  @include transition(background);
+
   align-items: center;
   background: transparent;
   border: 0;
@@ -95,7 +98,6 @@
   outline: none;
   padding: .5rem;
   user-select: none;
-  @include transition(all);
 
   &:active,
   &:focus,

--- a/base/_tables.scss
+++ b/base/_tables.scss
@@ -59,3 +59,74 @@
     border-bottom: 0;
   }
 }
+
+.go-table-toolbar {
+  align-items: center;
+  display: flex;
+  font-size: 0.875rem;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+
+  @media (max-width: $breakpoint-mobile) {
+    flex-wrap: wrap;
+  }
+}
+
+.go-table-toolbar__page-controls {
+  align-items: center;
+  display: flex;
+
+  @media (max-width: $breakpoint-mobile) {
+    justify-content: space-between;
+    margin-top: 1rem;
+    width: 100%;
+  }
+}
+
+.go-table-toolbar__button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  font-size: 1rem;
+  margin: 0 .25rem;
+  outline: none;
+  padding: .5rem;
+  user-select: none;
+  @include transition(all);
+
+  &:active,
+  &:focus,
+  &:hover {
+    background: $theme-light-bg-hover;
+  }
+}
+
+.go-table-toolbar__button--disabled {
+  color: lighten($theme-light-color, 40);
+  cursor: not-allowed;
+  pointer-events: none;
+
+  &:active,
+  &:focus,
+  &:hover {
+    background: none;
+  }
+}
+
+.go-table-toolbar__icon {
+  height: 1rem;
+}
+
+.go-table-toolbar__select {
+  font-size: 0.875rem;
+  height: 2rem;
+}
+
+.go-table-toolbar__label {
+  display: inline-block;
+  font-weight: normal;
+  padding: 0 0.75rem;
+}

--- a/gosheets.scss
+++ b/gosheets.scss
@@ -5,5 +5,6 @@
 @import './base/icons';
 @import './base/forms';
 @import './base/buttons';
+@import './base/tables';
 @import './base/hints';
 @import './base/placeholders';


### PR DESCRIPTION
## Source
https://github.com/mobi/goponents/blob/master/projects/go-lib/src/lib/components/go-table/go-table.component.scss

## Adds styles for go-table
This abstracts the styles out of the [goponents table component](https://github.com/mobi/goponents/blob/master/projects/go-lib/src/lib/components/go-table/go-table.component.scss) and
brings them in to gosheets. This will help us begin to flush out
the new table design before we get to Angular proper. This only
includes the styles for the main table and not for any of the
controls so some alterations might still need to be made to make
this work consistently.

## Adds additional styles for table toolbar
This pulls additional styles out of the goponent table component.