### PR TITLE
Added modifier class to collapse column

### DIFF
--- a/base/_grid.scss
+++ b/base/_grid.scss
@@ -38,3 +38,13 @@
     }
   }
 }
+
+.go-column--collapse {
+  flex-basis: auto;
+  flex-grow: 0;
+  width: auto;
+}
+
+.go-container--align-center {
+  align-items: center;
+}


### PR DESCRIPTION
## Source
https://mobi.teamwork.com/#tasks/13544489

`.go-column--collapse` makes the column collapse to the smallest it will go, allowing other columns in the same row to grow to fill the space.

`.go-container--align-center` makes the items underneath it align vertically centered