### PR TITLE
Added display property to anchor elements to enforce bottom border

### DIFF
--- a/base/_typography.scss
+++ b/base/_typography.scss
@@ -77,6 +77,7 @@ p,
 a:not([class]) {
   border-bottom: 1px solid;
   color: $theme-light-color;
+  display: inline-block;
   transition: $global-transition-duration $global-transition-timing;
 
   &:active,


### PR DESCRIPTION
## Source
https://mobi.teamwork.com/#tasks/13544480

We need to have this property on the class because borders don't automatically show up on inline elements and by default, anchors are inline.