### PR TITLE
Adds styles for icon buttons

### DIFF
--- a/base/_icon_buttons.scss
+++ b/base/_icon_buttons.scss
@@ -1,0 +1,15 @@
+.go-icon-button {
+  @include transition(background-color);
+
+  border: 0;
+  border-radius: $global-radius--round;
+  color: $base-dark;
+  cursor: pointer;
+  display: inline-flex;
+  outline-color: $theme-light-border;
+  padding: .5rem;
+
+  &:hover {
+    background-color: $theme-light-bg-hover;
+  }
+}

--- a/base/_icons.scss
+++ b/base/_icons.scss
@@ -1,3 +1,5 @@
+$icon-sizes: (small: 1rem, medium: 1.5rem, large: 2rem);
+
 // This .go-icon selector styles are borrowed verbatim from the material
 // icons documentation and applied to our own bem style block class.
 .go-icon {
@@ -40,4 +42,10 @@
 
 .go-icon--positive {
   @include fill-text-background($ui-color-positive-gradient, $ui-color-positive);
+}
+
+@each $name, $size in $icon-sizes {
+  .go-icon--#{$name} {
+    font-size: $size;
+  }
 }

--- a/base/_variables.scss
+++ b/base/_variables.scss
@@ -3,6 +3,7 @@
 
 // Presentational
 $global-radius: 4px;
+$global-radius--round: 100%;
 $global-transition-timing: cubic-bezier(.25, .8, .25, 1);
 $global-transition-duration: .25s;
 $global-box-shadow: 0 3px 6px rgba(0, 0, 0, .2);

--- a/gosheets.scss
+++ b/gosheets.scss
@@ -5,6 +5,7 @@
 @import './base/icons';
 @import './base/forms';
 @import './base/buttons';
+@import './base/icon_buttons';
 @import './base/tables';
 @import './base/hints';
 @import './base/placeholders';


### PR DESCRIPTION
The icon button UI can be used when we need to have a simple icon
that triggers and action of some sort. For example, a little "x"
icon in the top right of a modal to close out the modal.

<img width="296" alt="Screen Shot 2019-06-18 at 4 37 13 PM" src="https://user-images.githubusercontent.com/1075489/59718087-5faa9b00-91e7-11e9-8112-a2d69f5a4c65.png">

#### Implementation
Below are a few examples of how to implement this new UI:
```html
<button class="go-icon-button" aria-label="Close Modal">
  <i class="go-icon">close</i>
</button>
<button class="go-icon-button" aria-label="Close Modal">
  <i class="go-icon go-icon--small">close</i>
</button>
<button class="go-icon-button" aria-label="Close Modal">
  <i class="go-icon go-icon--medium">close</i>
</button>
<button class="go-icon-button" aria-label="Close Modal">
  <i class="go-icon go-icon--positive go-icon--large">close</i>
</button>
```
