### PR TITLE
Removes element selectors from typographic elements

### DIFF
--- a/base/_typography.scss
+++ b/base/_typography.scss
@@ -2,7 +2,6 @@ body {
   font-family: $base-font-stack;
 }
 
-h1,
 .go-heading-1 {
   font-family: $heading-font-stack;
   font-size: 6rem;
@@ -11,7 +10,6 @@ h1,
   margin-bottom: $column-gutter--quarter;
 }
 
-h2,
 .go-heading-2 {
   font-family: $heading-font-stack;
   font-size: 3.75rem;
@@ -20,7 +18,6 @@ h2,
   margin-bottom: $column-gutter--quarter;
 }
 
-h3,
 .go-heading-3 {
   font-family: $heading-font-stack;
   font-size: 3rem;
@@ -30,7 +27,6 @@ h3,
   margin-bottom: $column-gutter--quarter;
 }
 
-h4,
 .go-heading-4 {
   font-family: $heading-font-stack;
   font-size: 2.125rem;
@@ -40,7 +36,6 @@ h4,
   margin-bottom: $column-gutter--quarter;
 }
 
-h5,
 .go-heading-5 {
   font-family: $heading-font-stack;
   font-size: 1.5rem;
@@ -50,7 +45,6 @@ h5,
   margin-bottom: $column-gutter--half;
 }
 
-h6,
 .go-heading-6 {
   font-family: $heading-font-stack;
   font-size: .875rem;
@@ -60,7 +54,6 @@ h6,
   margin-bottom: $column-gutter--half;
 }
 
-p,
 .go-body-copy {
   font-size: 1rem;
   letter-spacing: .5pt;
@@ -75,10 +68,11 @@ p,
 
 .go-link,
 a:not([class]) {
+  @include transition;
+
   border-bottom: 1px solid;
   color: $theme-light-color;
   display: inline-block;
-  transition: $global-transition-duration $global-transition-timing;
 
   &:active,
   &:focus,


### PR DESCRIPTION
Applying styles directly on elements makes it hard to transition
from and existing design to gosheets. This removes the element
selectors from our typographic styles to help with the transition.